### PR TITLE
Add comprehensive organizer handbook to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,130 @@
 # madclj.com
 
-Website for Madison Clojure.
+Website for Madison Clojure, a Clojure user group in Madison, Wisconsin.
 
 ![Madison Clojure](static/images/madclj-logo.jpg)
 
-## Usage
+## Quick Start
 
-Install [Hugo](https://gohugo.io/installation/).
+Install [Hugo](https://gohugo.io/installation/), then:
 
-Run `./serve.sh` to start the server.
+```bash
+./serve.sh  # starts server at http://localhost:1313
+```
 
-## Creating a new event
+---
 
-1. Create a new pinned announcement in https://github.com/orgs/madclj/discussions
-   - note only pinned announcements get rsvp counts
-2. Add a new entry to `madison-clojure.events/events` with the url to discussion as the `:rsvp`
+## For Organizers: Creating & Managing Meetups
+
+This repo uses a dual-record system:
+- **Calendar** (`events.clj`): Generic titles/descriptions, auto-synced to madclj.com and .ics feeds
+- **Discussions** (GitHub): Detailed agenda, topics, RSVPs, updates
+
+⚠️ **These do NOT auto-sync.** Changes must be made in both places if you modify time/date/location.
+
+### Create a New Event
+
+**1. Create a GitHub discussion** at https://github.com/orgs/madclj/discussions
+   - Write the title, agenda, topics, and any prep needed
+   - Pin the discussion (only pinned discussions count for RSVP metrics)
+   - Copy the discussion URL
+
+**2. Add event to `feeds/src/madison_clojure/events.clj`**
+
+```clojure
+{:full-title "January 14th Meetup"
+ :summary "January 14th Meetup"
+ :uid "https://github.com/orgs/madclj/discussions/37"
+ :rsvp "https://github.com/orgs/madclj/discussions/37"
+ :description (text "Generic description or TBD")
+ :location startingblock  ; or startingblock-pop for 3rd floor
+ :start (madison-time "2026-01-14T18:30")
+ :end (madison-time "2026-01-14T21:00")}
+```
+
+Keep `:summary` and `:description` generic—specific details live in the GitHub discussion.
+
+**3. Commit & push**
+   - Create a PR (main branch is protected)
+   - As a maintainer, merge with bypass
+   - For quick edits, use GitHub's web editor for `events.clj`
+
+### Update or Cancel an Event
+
+**To change time/date/location:**
+- Update `events.clj` (commit via PR)
+- Post a comment in the GitHub discussion
+- Update the discussion title if needed
+
+**To cancel:** Don't delete it. Instead:
+- Add `:cancelled true` to the event
+- Prefix titles with "CANCELLED "
+
+```clojure
+{:full-title "CANCELLED May 14th Meetup"
+ :summary "CANCELLED May 14th Meetup"
+ :cancelled true
+ ...}
+```
+
+### Remind Attendees
+
+Use `@madclj/meetup` in a discussion comment 3–7 days before the event.
+
+### After the Event
+
+1. **Update the discussion title** — add "DONE" prefix
+2. **Unpin the discussion**
+3. **Pin the next upcoming event** — so it's visible and collecting RSVPs
+
+This keeps the calendar organized and ensures attendees see the current event.
+
+### Plan a New Year
+
+At the start of each year, create placeholder events (second Wednesday of each month):
+- Use `seed-events-2026` in `events.clj` as a template
+- Set `:description` to "TBD" initially
+- Update with real topics as decisions are made
+
+---
 
 ## FAQ
 
-Q: RSVP counts are not updating on madclj.com.
-A: Ensure the latest announcements are pinned, and that the [scheduled workflow updating RSVP's](https://github.com/madclj/madclj.com/actions/workflows/hugo.yaml) is not disabled due to inactivity.
+**RSVP counts not updating?**
+- Ensure the discussion is pinned
+- Check the discussion URL in `events.clj` matches exactly
+- The workflow runs at 2 AM & 2 PM Madison time (or manually trigger from Actions tab)
+
+**Event not on calendar?**
+- Verify `:uid` matches the GitHub discussion URL exactly
+- Check `:start` and `:end` times
+- Confirm the workflow succeeded (github.com/madclj/madclj.com/actions)
+
+---
+
+## Technical Details
+
+**Calendar generation:**
+1. Edit `feeds/src/madison_clojure/events.clj`
+2. Push to main
+3. GitHub Actions workflow runs `script/gen-calendar`
+4. Generates `events.ics`, updates `content/_index.markdown`
+5. Hugo builds site; deploys to GitHub Pages
+
+**Key files:**
+- `feeds/src/madison_clojure/events.clj` — event definitions
+- `script/build` — full build pipeline
+- `.github/workflows/hugo.yaml` — CI/CD config
+
+**Locations:**
+- `startingblock` — 821 E Washington Ave, 2nd floor
+- `startingblock-pop` — 821 E Washington Ave, 3rd floor ("Pop" conference room)
+
+---
+
+## Useful Links
+
+- **Website**: https://madclj.com
+- **Discussions**: https://github.com/orgs/madclj/discussions
+- **Repository**: https://github.com/madclj/madclj.com
+- **Actions/Workflows**: https://github.com/madclj/madclj.com/actions/workflows/hugo.yaml

--- a/content/_index.markdown
+++ b/content/_index.markdown
@@ -15,6 +15,17 @@ title: Home
 
 [Download Calendar (.ics)](events.ics)
 
+---
+
+### For Organizers
+
+Want to organize a meetup? See the [Organizer Guide](https://github.com/madclj/madclj.com#for-organizers-creating--managing-meetups) in the repository README for detailed instructions on:
+- Creating new events
+- Updating and cancelling events
+- Reminding attendees
+- Post-event procedures
+
+[📋 Full Organizer Guide](https://github.com/madclj/madclj.com#for-organizers-creating--managing-meetups)
 
 <!--
 |Nov 13th 2024 (Past)|[Clojure Conference Takeaways and Inspirations](https://github.com/orgs/madclj/discussions/6)|4|


### PR DESCRIPTION
Documents the complete workflow for managing Madison Clojure meetups:
- Creating new events (dual-record system with events.clj and GitHub discussions)
- Updating and cancelling events
- Reminding attendees with `@madclj/meetup`
- Post-event procedures (mark DONE, unpin, pin next event)
- Year-end planning with placeholder events

Includes technical details on calendar generation, key files, and troubleshooting. Updated website footer to link organizers to the guide.